### PR TITLE
🔒 [Security Fix] Prevent DoS via Division by Zero in Voltage Calculations

### DIFF
--- a/load_calcs.py
+++ b/load_calcs.py
@@ -23,7 +23,7 @@ class ElectricalRizz:
             float: The voltage drop percentage. If it's high, you need to lock in.
         
         Reference:
-            [span_0](start_span)Based on Chapter 5: Wire and Cable Systems[span_0](end_span).
+            Based on Chapter 5: Wire and Cable Systems.
         """
         # K-factor: Copper = 12.9, Aluminum = 21.2 (Approximations for that quick maffs)
         k_factor = 12.9 if material.lower() == 'copper' else 21.2
@@ -37,6 +37,9 @@ class ElectricalRizz:
         
         if wire_gauge not in cmil_map:
             return -1.0 # Error: We don't mess with that unknown wire gauge.
+
+        if voltage <= 0:
+            return -1.0 # Error: Voltage cannot be zero or negative.
 
         cmils = cmil_map[wire_gauge]
         
@@ -61,7 +64,7 @@ class ElectricalRizz:
             bool: True if you're valid (Sigma), False if you're violating (Beta).
             
         Reference:
-            [span_1](start_span)Based on Chapter 3: Conduit Systems[span_1](end_span).
+            Based on Chapter 3: Conduit Systems.
             1 conductor = 53% max fill
             2 conductors = 31% max fill
             3+ conductors = 40% max fill
@@ -90,7 +93,7 @@ class ElectricalRizz:
             float: Total shrink amount in inches. Add this or your fit is mid.
             
         Reference:
-            [span_2](start_span)Chapter 3: Bending Fundamentals[span_2](end_span).
+            Chapter 3: Bending Fundamentals.
             Multipliers: 30deg = 0.26 shrink/inch.
         """
         # Shrink constants per inch of rise
@@ -99,7 +102,7 @@ class ElectricalRizz:
             22.5: 0.19, # rounded from 3/16
             30: 0.25,   # 1/4 inch
             45: 0.38,   # 3/8 inch
-            [span_3](start_span)60: 0.58    #[span_3](end_span)
+            60: 0.58
         }
         
         if angle not in shrink_map:
@@ -116,7 +119,7 @@ class ElectricalRizz:
         Prints the LOTO steps so you don't end up on a T-shirt.
         
         Reference:
-            [span_4](start_span)Chapter 2: Jobsite Safety[span_4](end_span).
+            Chapter 2: Jobsite Safety.
         """
         steps = [
             "1. Identify the ops (energy sources).",

--- a/test_load_calcs_security.py
+++ b/test_load_calcs_security.py
@@ -1,0 +1,36 @@
+import pytest
+from load_calcs import ElectricalRizz
+
+class TestElectricalRizzSecurity:
+
+    def setup_method(self):
+        self.rizz = ElectricalRizz()
+
+    def test_zero_voltage_returns_error(self):
+        """Test that voltage=0 returns -1.0 error code instead of raising ZeroDivisionError."""
+        result = self.rizz.calculate_voltage_drop(voltage=0, current=10, length=100, wire_gauge=12)
+        assert result == -1.0, "Should return -1.0 for zero voltage"
+
+    def test_negative_voltage_returns_error(self):
+        """Test that negative voltage returns -1.0 error code."""
+        result = self.rizz.calculate_voltage_drop(voltage=-120, current=10, length=100, wire_gauge=12)
+        assert result == -1.0, "Should return -1.0 for negative voltage"
+
+    def test_valid_inputs_return_percentage(self):
+        """Test that valid inputs return a positive float."""
+        # K=12.9 (copper), L=100, I=10, CM=6530 (12 AWG), V=120
+        # VD_volts = (2 * 12.9 * 100 * 10) / 6530 = 25800 / 6530 ≈ 3.951
+        # VD_percent = (3.951 / 120) * 100 ≈ 3.29
+        result = self.rizz.calculate_voltage_drop(voltage=120, current=10, length=100, wire_gauge=12)
+        assert result > 0
+        assert abs(result - 3.29) < 0.1 # approximate check
+
+    def test_zero_length_returns_zero_drop(self):
+        """Test that zero length results in 0% drop (valid)."""
+        result = self.rizz.calculate_voltage_drop(voltage=120, current=10, length=0, wire_gauge=12)
+        assert result == 0.0
+
+    def test_zero_current_returns_zero_drop(self):
+        """Test that zero current results in 0% drop (valid)."""
+        result = self.rizz.calculate_voltage_drop(voltage=120, current=0, length=100, wire_gauge=12)
+        assert result == 0.0


### PR DESCRIPTION
🎯 **What:**
Fixed a `ZeroDivisionError` in `calculate_voltage_drop` occurring when `voltage` parameter is provided as zero or negative.
Also cleaned up `[span_X]` markers that were causing syntax errors in `load_calcs.py`.

⚠️ **Risk:**
An attacker or accidental malformed input could trigger an unhandled exception (division by zero), leading to a Denial of Service (DoS) by crashing the calculation process.

🛡️ **Solution:**
- Added a validation check for `voltage <= 0`.
- Returns `-1.0` (error code) if voltage is invalid, consistent with existing error handling for invalid wire gauge.
- Added comprehensive unit tests in `test_load_calcs_security.py` covering edge cases.


---
*PR created automatically by Jules for task [8404545125256126245](https://jules.google.com/task/8404545125256126245) started by @Turbo-the-tech-dev*